### PR TITLE
IP 스푸핑 방지 및 ruby 문법 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Pull Request 시 서버 코드에는 `?.`, `??`, `import` 등의 신문법, 프�
   - `protect_owner`: (기본값 false) 소유자 보호 기능을 활성화한다.
   - `disable_multithreading`: (기본값 true) 멀티쓰레딩을 비활성화한다.
   - `custom_namespaces`: (기본값 []) 사용자 지정 이름공간 배열
+  - `custom_ip_header`: (기본값 x-forwarded-for) IP를 가져올 헤더를 자유롭게 지정
+  - `use_cloudflare`: (기본값 false) cloudflare를 사용하는 경우 IP를 CF_Connecting_IP에서 가져옴
   - `sessionhttp`: (기본값 false) true로 설정시, https접속시에만 로그인이 유지된다.
   - `mailhost`: (기본값 []) 이메일 호스트 설정.
   - `email`: (기본값 []) 이메일 주소.

--- a/hostconfig.js
+++ b/hostconfig.js
@@ -15,7 +15,11 @@ if(hostconfig.disable_file_server === undefined)
 if(hostconfig.database_type === undefined)
 	hostconfig.database_type = (process.env.DATABASE_TYPE || '').toLowerCase() || 'sqlite';
 
-// IP 스푸핑 방지(CloudFlare 연계), newseed.xyz(op@newseed.xyz) all right reserved.
+// IP 스푸핑 방지(CloudFlare 연계) 18~24 Line, newseed.xyz(op@newseed.xyz) all right reserved.
+
+if(hostconfig.use_cloudflare === undefined)
+	hostconfig.use_cloudflare = false;
+
 if(hostconfig.use_cloudflare === true && hostconfig.custom_ip_header === undefined)
 	hostconfig.custom_ip_header = "CF_Connecting_IP";
 

--- a/hostconfig.js
+++ b/hostconfig.js
@@ -15,6 +15,7 @@ if(hostconfig.disable_file_server === undefined)
 if(hostconfig.database_type === undefined)
 	hostconfig.database_type = (process.env.DATABASE_TYPE || '').toLowerCase() || 'sqlite';
 
+// IP 스푸핑 방지(CloudFlare 연계), newseed.xyz(op@newseed.xyz) all right reserved.
 if(hostconfig.use_cloudflare === true && hostconfig.custom_ip_header === undefined)
 	hostconfig.custom_ip_header = "CF_Connecting_IP";
 

--- a/hostconfig.js
+++ b/hostconfig.js
@@ -15,4 +15,7 @@ if(hostconfig.disable_file_server === undefined)
 if(hostconfig.database_type === undefined)
 	hostconfig.database_type = (process.env.DATABASE_TYPE || '').toLowerCase() || 'sqlite';
 
+if(hostconfig.use_cloudflare === true && hostconfig.custom_ip_header === undefined)
+	hostconfig.custom_ip_header = "CF_Connecting_IP";
+
 module.exports = hostconfig;

--- a/namumark_parser.js
+++ b/namumark_parser.js
@@ -514,8 +514,8 @@ module.exports = async function markdown(req, content, discussion = 0, title = '
 	
 	data += '\r\n';
 
-	data = ruby(data);
 	data = html.escape(data);
+	data = ruby(data);
 	const xref = flags.includes('backlinkinit');
 	
 // ruby 문법 515, 519~531 Line, newseed.xyz(op@newseed.xyz) all right reserved.

--- a/namumark_parser.js
+++ b/namumark_parser.js
@@ -518,19 +518,6 @@ module.exports = async function markdown(req, content, discussion = 0, title = '
 	data = ruby(data);
 	const xref = flags.includes('backlinkinit');
 	
-// ruby 문법 515, 519~531 Line, newseed.xyz(op@newseed.xyz) all right reserved.
-    function ruby(text) {
-        const rubyPattern = /\[ruby\(([^,]+),\s*ruby=([^,\)]+)(?:,\s*color=?\{?([^\}\)]+)\}?)?\)\]/g;
-        const cssColors = functions.cssColors; // functions.js의 cssColors 변수 사용
-
-        return text.replace(rubyPattern, (match, kanji, furigana, color) => {
-            if (color && cssColors.includes(color) || color && csscolors.includes(color)) {
-                return `<ruby>${kanji}<rp>(</rp><rt style="color: ${color};">${furigana}</rt><rp>)</rp></ruby>`;
-            } else {
-                return `<ruby>${kanji}<rp>(</rp><rt>${furigana}</rt><rp>)</rp></ruby>`;
-            }
-        });
-    }
 	// 역링크 초기화
 	if(xref)
 		await curs.execute("delete from backlink where title = ? and namespace = ?", [doc.title, doc.namespace]);
@@ -671,7 +658,21 @@ module.exports = async function markdown(req, content, discussion = 0, title = '
 		item.outerHTML = key;
 	}
 	data = document.querySelector('body').innerHTML.replace(/<br>/g, '\n');
-	
+
+	// ruby 문법 515, 519~531 Line, newseed.xyz(op@newseed.xyz) all right reserved.
+	function ruby(text) {
+        	const rubyPattern = /\[ruby\(([^,]+),\s*ruby=([^,\)]+)(?:,\s*color=?\{?([^\}\)]+)\}?)?\)\]/g;
+        	const cssColors = functions.cssColors; // functions.js의 cssColors 변수 사용
+
+        	return text.replace(rubyPattern, (match, kanji, furigana, color) => {
+            		if (color && cssColors.includes(color) || color && csscolors.includes(color)) {
+                		return `<ruby>${kanji}<rp>(</rp><rt style="color: ${color};">${furigana}</rt><rp>)</rp></ruby>`;
+            		} else {
+                		return `<ruby>${kanji}<rp>(</rp><rt>${furigana}</rt><rp>)</rp></ruby>`;
+            		}
+        	});
+    	}
+
 	// 각주
 	var rdata = {}, tdata = {}, tdata2 = {};
 	function parseFootnotes() {

--- a/namumark_parser.js
+++ b/namumark_parser.js
@@ -515,15 +515,13 @@ module.exports = async function markdown(req, content, discussion = 0, title = '
 	data = ruby(data);
 	data = html.escape(data);
 	const xref = flags.includes('backlinkinit');
-
+// ruby 문법, newseed.xyz(op@newseed.xyz) all right reserved.
     function ruby(text) {
         const rubyPattern = /\[ruby\(([^,]+),\s*ruby=([^,\)]+)(?:,\s*color=?\{?([^\}\)]+)\}?)?\)\]/g;
         const cssColors = functions.cssColors; // functions.js의 cssColors 변수 사용
-        const cssColorsmalls = ['black', 'gray', 'grey', 'silver', 'white', 'red', 'maroon', 'yellow', 'olive', 'lime', 'green', 'aqua', 'cyan', 'teal', 'blue', 'navy', 'magenta', 'fuchsia', 'purple', 'dimgray', 'dimgrey', 'darkgray', 'darkgrey', 'lightgray', 'lightgrey', 'gainsboro', 'whitesmoke', 'brown', 'darkred', 'firebrick', 'indianred', 'lightcoral', 'rosybrown', 'snow', 'mistyrose', 'salmon', 'tomato', 'darksalmon', 'coral', 'orangered', 'lightsalmon', 'sienna', 'seashell', 'chocolate', 'saddlebrown', 'sandybrown', 'peachpuff', 'peru', 'linen', 'bisque', 'darkorange', 'burlywood', 'antiquewhite', 'tan', 'navajowhite', 'blanchedalmond', 'papayawhip', 'moccasin', 'orange', 'wheat', 'oldlace', 'floralwhite', 'darkgoldenrod', 'goldenrod', 'cornsilk', 'gold', 'khaki', 'lemonchiffon', 'palegoldenrod', 'darkkhaki', 'beige', 'ivory', 'lightgoldenrodyellow', 'lightyellow', 'olivedrab', 'yellowgreen', 'darkolivegreen', 'greenyellow', 'chartreuse', 'lawngreen', 'darkgreen', 'darkseagreen', 'forestgreen', 'honeydew', 'lightgreen', 'limegreen', 'palegreen', 'seagreen', 'mediumseagreen', 'springgreen', 'mintcream', 'mediumspringgreen', 'mediumaquamarine', 'aquamarine', 'turquoise', 'lightseagreen', 'mediumturquoise', 'azure', 'darkcyan', 'darkslategray', 'darkslategrey', 'lightcyan', 'paleturquoise', 'darkturquoise', 'cadetblue', 'powderblue', 'lightblue', 'deepskyblue', 'skyblue', 'lightskyblue', 'steelblue', 'aliceblue', 'dodgerblue', 'lightslategray', 'lightslategrey', 'slategray', 'slategrey', 'lightsteelblue', 'cornflowerblue', 'royalblue', 'darkblue', 'ghostwhite', 'lavender', 'mediumblue', 'midnightblue', 'slateblue', 'darkslateblue', 'mediumslateblue', 'mediumpurple', 'rebeccapurple', 'blueviolet', 'indigo', 'darkorchid', 'darkviolet', 'mediumorchid', 'darkmagenta', 'plum', 'thistle', 'violet', 'orchid', 'mediumvioletred', 'deeppink', 'hotpink', 'lavenderblush', 'palevioletred', 'crimson', 'pink', 'lightpink'];
-
 
         return text.replace(rubyPattern, (match, kanji, furigana, color) => {
-            if (color && cssColors.includes(color) || color && cssColorsmalls.includes(color)) {
+            if (color && cssColors.includes(color) || color && cssColors.toLowerCase().includes(color)) {
                 return `<ruby>${kanji}<rp>(</rp><rt style="color: ${color};">${furigana}</rt><rp>)</rp></ruby>`;
             } else {
                 return `<ruby>${kanji}<rp>(</rp><rt>${furigana}</rt><rp>)</rp></ruby>`;

--- a/namumark_parser.js
+++ b/namumark_parser.js
@@ -511,10 +511,25 @@ module.exports = async function markdown(req, content, discussion = 0, title = '
 	root = root || title;
 	
 	data += '\r\n';
-	
+
+	data = ruby(data);
 	data = html.escape(data);
 	const xref = flags.includes('backlinkinit');
-	
+
+    function ruby(text) {
+        const rubyPattern = /\[ruby\(([^,]+),\s*ruby=([^,\)]+)(?:,\s*color=?\{?([^\}\)]+)\}?)?\)\]/g;
+        const cssColors = functions.cssColors; // functions.js의 cssColors 변수 사용
+        const cssColorsmalls = ['black', 'gray', 'grey', 'silver', 'white', 'red', 'maroon', 'yellow', 'olive', 'lime', 'green', 'aqua', 'cyan', 'teal', 'blue', 'navy', 'magenta', 'fuchsia', 'purple', 'dimgray', 'dimgrey', 'darkgray', 'darkgrey', 'lightgray', 'lightgrey', 'gainsboro', 'whitesmoke', 'brown', 'darkred', 'firebrick', 'indianred', 'lightcoral', 'rosybrown', 'snow', 'mistyrose', 'salmon', 'tomato', 'darksalmon', 'coral', 'orangered', 'lightsalmon', 'sienna', 'seashell', 'chocolate', 'saddlebrown', 'sandybrown', 'peachpuff', 'peru', 'linen', 'bisque', 'darkorange', 'burlywood', 'antiquewhite', 'tan', 'navajowhite', 'blanchedalmond', 'papayawhip', 'moccasin', 'orange', 'wheat', 'oldlace', 'floralwhite', 'darkgoldenrod', 'goldenrod', 'cornsilk', 'gold', 'khaki', 'lemonchiffon', 'palegoldenrod', 'darkkhaki', 'beige', 'ivory', 'lightgoldenrodyellow', 'lightyellow', 'olivedrab', 'yellowgreen', 'darkolivegreen', 'greenyellow', 'chartreuse', 'lawngreen', 'darkgreen', 'darkseagreen', 'forestgreen', 'honeydew', 'lightgreen', 'limegreen', 'palegreen', 'seagreen', 'mediumseagreen', 'springgreen', 'mintcream', 'mediumspringgreen', 'mediumaquamarine', 'aquamarine', 'turquoise', 'lightseagreen', 'mediumturquoise', 'azure', 'darkcyan', 'darkslategray', 'darkslategrey', 'lightcyan', 'paleturquoise', 'darkturquoise', 'cadetblue', 'powderblue', 'lightblue', 'deepskyblue', 'skyblue', 'lightskyblue', 'steelblue', 'aliceblue', 'dodgerblue', 'lightslategray', 'lightslategrey', 'slategray', 'slategrey', 'lightsteelblue', 'cornflowerblue', 'royalblue', 'darkblue', 'ghostwhite', 'lavender', 'mediumblue', 'midnightblue', 'slateblue', 'darkslateblue', 'mediumslateblue', 'mediumpurple', 'rebeccapurple', 'blueviolet', 'indigo', 'darkorchid', 'darkviolet', 'mediumorchid', 'darkmagenta', 'plum', 'thistle', 'violet', 'orchid', 'mediumvioletred', 'deeppink', 'hotpink', 'lavenderblush', 'palevioletred', 'crimson', 'pink', 'lightpink'];
+
+
+        return text.replace(rubyPattern, (match, kanji, furigana, color) => {
+            if (color && cssColors.includes(color) || color && cssColorsmalls.includes(color)) {
+                return `<ruby>${kanji}<rp>(</rp><rt style="color: ${color};">${furigana}</rt><rp>)</rp></ruby>`;
+            } else {
+                return `<ruby>${kanji}<rp>(</rp><rt>${furigana}</rt><rp>)</rp></ruby>`;
+            }
+        });
+    }
 	// 역링크 초기화
 	if(xref)
 		await curs.execute("delete from backlink where title = ? and namespace = ?", [doc.title, doc.namespace]);

--- a/namumark_parser.js
+++ b/namumark_parser.js
@@ -660,19 +660,6 @@ module.exports = async function markdown(req, content, discussion = 0, title = '
 
 	const colors = functions.cssColors.map(color => color.toLowerCase());
 
-	// ruby 문법 661~674 Line, newseed.xyz(op@newseed.xyz) all right reserved.
-	function ruby(text) {
-        	const rubyPattern = /\[ruby\(([^,]+),\s*ruby=([^,\)]+)(?:,\s*color=?\{?([^\}\)]+)\}?)?\)\]/g;
-
-        	return text.replace(rubyPattern, (match, kanji, furigana, color) => {
-            		if (color && colors.includes(color)) {
-                		return `<ruby>${kanji}<rp>(</rp><rt style="color: ${color};">${furigana}</rt><rp>)</rp></ruby>`;
-            		} else {
-                		return `<ruby>${kanji}<rp>(</rp><rt>${furigana}</rt><rp>)</rp></ruby>`;
-            		}
-        	});
-    	}
-
 	// 각주
 	var rdata = {}, tdata = {}, tdata2 = {};
 	function parseFootnotes() {
@@ -1042,6 +1029,20 @@ module.exports = async function markdown(req, content, discussion = 0, title = '
 	for(let fpcm of (data.match(/\[pagecount\((((?!\)).)*)\)\]/gi) || [])) {
 		let pcm = fpcm.match(/\[pagecount\((((?!\)).)*)\)\]/i);
 		data = data.replace(fpcm, pgcnt[pcm[1]] === undefined ? pgcnta : pgcnt[pcm[1]]);
+	}
+
+		
+        // ruby 문법 1035~1046 Line, newseed.xyz(op@newseed.xyz) all right reserved.
+	function ruby(text) {
+        	const rubyPattern = /\[ruby\(([^,]+),\s*ruby=([^,\)]+)(?:,\s*color=?\?([^\}\)]+)\?)?\)\]/g;
+
+        	return text.replace(rubyPattern, (match, kanji, furigana, color) => {
+            		if (color && colors.includes(color)) {
+                		return `<ruby>${kanji}<rp>(</rp><rt style="color: ${color};">${furigana}</rt><rp>)</rp></ruby>`;
+            		} else {
+                		return `<ruby>${kanji}<rp>(</rp><rt>${furigana}</rt><rp>)</rp></ruby>`;
+            		}
+        	});
 	}
 	
 	// 동화상

--- a/namumark_parser.js
+++ b/namumark_parser.js
@@ -25,6 +25,8 @@ function jsdom(content) {
 
 const hostconfig = require('./hostconfig');
 const functions = require('./functions');
+const colors = cssColors.map(color => color.toLowerCase());
+
 for(var item in functions) global[item] = functions[item];
 
 const rHeadings = 
@@ -522,7 +524,7 @@ module.exports = async function markdown(req, content, discussion = 0, title = '
         const cssColors = functions.cssColors; // functions.js의 cssColors 변수 사용
 
         return text.replace(rubyPattern, (match, kanji, furigana, color) => {
-            if (color && cssColors.includes(color) || color && cssColors.toLowerCase().includes(color)) {
+            if (color && cssColors.includes(color) || color && csscolors.includes(color)) {
                 return `<ruby>${kanji}<rp>(</rp><rt style="color: ${color};">${furigana}</rt><rp>)</rp></ruby>`;
             } else {
                 return `<ruby>${kanji}<rp>(</rp><rt>${furigana}</rt><rp>)</rp></ruby>`;

--- a/namumark_parser.js
+++ b/namumark_parser.js
@@ -25,7 +25,6 @@ function jsdom(content) {
 
 const hostconfig = require('./hostconfig');
 const functions = require('./functions');
-const colors = cssColors.map(color => color.toLowerCase());
 
 for(var item in functions) global[item] = functions[item];
 
@@ -659,13 +658,14 @@ module.exports = async function markdown(req, content, discussion = 0, title = '
 	}
 	data = document.querySelector('body').innerHTML.replace(/<br>/g, '\n');
 
-	// ruby 문법 515, 519~531 Line, newseed.xyz(op@newseed.xyz) all right reserved.
+	const colors = functions.cssColors.map(color => color.toLowerCase());
+
+	// ruby 문법 661~674 Line, newseed.xyz(op@newseed.xyz) all right reserved.
 	function ruby(text) {
         	const rubyPattern = /\[ruby\(([^,]+),\s*ruby=([^,\)]+)(?:,\s*color=?\{?([^\}\)]+)\}?)?\)\]/g;
-        	const cssColors = functions.cssColors; // functions.js의 cssColors 변수 사용
 
         	return text.replace(rubyPattern, (match, kanji, furigana, color) => {
-            		if (color && cssColors.includes(color) || color && csscolors.includes(color)) {
+            		if (color && colors.includes(color)) {
                 		return `<ruby>${kanji}<rp>(</rp><rt style="color: ${color};">${furigana}</rt><rp>)</rp></ruby>`;
             		} else {
                 		return `<ruby>${kanji}<rp>(</rp><rt>${furigana}</rt><rp>)</rp></ruby>`;

--- a/namumark_parser.js
+++ b/namumark_parser.js
@@ -515,7 +515,8 @@ module.exports = async function markdown(req, content, discussion = 0, title = '
 	data = ruby(data);
 	data = html.escape(data);
 	const xref = flags.includes('backlinkinit');
-// ruby 문법, newseed.xyz(op@newseed.xyz) all right reserved.
+	
+// ruby 문법 515, 519~531 Line, newseed.xyz(op@newseed.xyz) all right reserved.
     function ruby(text) {
         const rubyPattern = /\[ruby\(([^,]+),\s*ruby=([^,\)]+)(?:,\s*color=?\{?([^\}\)]+)\}?)?\)\]/g;
         const cssColors = functions.cssColors; // functions.js의 cssColors 변수 사용


### PR DESCRIPTION
# 서론

누가 그랬는지 별도로 명시하지는 않겠으나 [어떤 정신나간 위키 소유자](https://github.com/NOAH01112)가 본 코드와 관련된 계약을 위반하여 계약에 따라 오픈소스로 전환된 사항입니다.

# 추가 사항

추가된 사항은 다음과 같습니다.

 - IP 스푸핑 방지(CloudFlare 연계) 
 - Ruby 문법 지원(ex: [ruby(라이선스, ruby=위반 작작해라, color=red)])

# 주의 사항
 - IP 스푸핑 방지를 원하시면 config.json에서 아래와 같이 바꾸신 뒤, **cloudflare 프록시 설정을 on으로 바꿔주세요.**
 ```json
 {"use_cloudflare":"true"}
 ```
 - ruby 문법은 the seed와 매우 유사하게 작동합니다.
 - 본 PR에 적용된 코드는 all right reserved입니다.